### PR TITLE
Storage Image FIx

### DIFF
--- a/Cocktail/Cocktail.xcodeproj/project.pbxproj
+++ b/Cocktail/Cocktail.xcodeproj/project.pbxproj
@@ -544,7 +544,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "heesung.Cocktail.Cocktail-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -573,7 +573,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "heesung.Cocktail.Cocktail-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -727,7 +727,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = heesung.Cocktail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -762,7 +762,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = heesung.Cocktail;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Cocktail/Cocktail.xcodeproj/project.pbxproj
+++ b/Cocktail/Cocktail.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3D4415CF27564CF400CBCC40 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 3D4415CE27564CF400CBCC40 /* GoogleSignIn */; };
 		3D4415D127564EA600CBCC40 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4415D027564EA600CBCC40 /* LoginViewController.swift */; };
 		3D4415D327565DA200CBCC40 /* ColorChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4415D227565DA200CBCC40 /* ColorChoiceViewController.swift */; };
+		3D48C2092759A672001B40FC /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3D48C2082759A672001B40FC /* Kingfisher */; };
 		3D647F2D2753327F005EE580 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3D647F2C2753327F005EE580 /* SnapKit */; };
 		3D6C6D3F27325F3400C70276 /* ChoiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6C6D3E27325F3400C70276 /* ChoiceViewController.swift */; };
 		3D6C6D412732AB5200C70276 /* CocktailListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6C6D402732AB5200C70276 /* CocktailListTableView.swift */; };
@@ -174,6 +175,7 @@
 				3D647F2D2753327F005EE580 /* SnapKit in Frameworks */,
 				3DB910E127574D720076CB50 /* FirebaseCrashlytics in Frameworks */,
 				3DB910DD27574D720076CB50 /* FirebaseAnalyticsSwift-Beta in Frameworks */,
+				3D48C2092759A672001B40FC /* Kingfisher in Frameworks */,
 				3DB910EF27574D720076CB50 /* FirebaseStorage in Frameworks */,
 				3DB910E327574D720076CB50 /* FirebaseDatabase in Frameworks */,
 				3DB910E527574D720076CB50 /* FirebaseDatabaseSwift-Beta in Frameworks */,
@@ -355,6 +357,7 @@
 				3DB910EC27574D720076CB50 /* FirebaseRemoteConfig */,
 				3DB910EE27574D720076CB50 /* FirebaseStorage */,
 				3DB910F027574D720076CB50 /* FirebaseStorageSwift-Beta */,
+				3D48C2082759A672001B40FC /* Kingfisher */,
 			);
 			productName = Cocktail;
 			productReference = 3DA76A2D2730D1CD004091CE /* Cocktail.app */;
@@ -392,6 +395,7 @@
 				3D647F2B2753327F005EE580 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				3D4415CD27564CF400CBCC40 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				3DB910D927574D720076CB50 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				3D48C2072759A671001B40FC /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 3DA76A2E2730D1CD004091CE /* Products */;
 			projectDirPath = "";
@@ -809,6 +813,14 @@
 				minimumVersion = 6.0.0;
 			};
 		};
+		3D48C2072759A671001B40FC /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.0.0;
+			};
+		};
 		3D647F2B2753327F005EE580 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -832,6 +844,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3D4415CD27564CF400CBCC40 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignIn;
+		};
+		3D48C2082759A672001B40FC /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3D48C2072759A671001B40FC /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 		3D647F2C2753327F005EE580 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Cocktail/Cocktail.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cocktail/Cocktail.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -101,6 +101,15 @@
         }
       },
       {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "318e319998bf555c3e914d5c3adb6da05af86a32",
+          "version": "7.1.1"
+        }
+      },
+      {
         "package": "leveldb",
         "repositoryURL": "https://github.com/firebase/leveldb.git",
         "state": {

--- a/Cocktail/Cocktail/ViewControllers/CocktailDetailViewController.swift
+++ b/Cocktail/Cocktail/ViewControllers/CocktailDetailViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SnapKit
+import Kingfisher
 
 class CocktailDetailViewController: UIViewController {
     
@@ -201,7 +202,15 @@ class CocktailDetailViewController: UIViewController {
         recipeLabel.text = data.recipe.localized
         myTipLabel.text = data.mytip.localized
         ingredientsLabel.text = data.ingredients.map {$0.rawValue.localized}.joined(separator: ", ")
-
+        
+        if let urlString = data.imageURL {
+            let imageURL = URL(string: urlString)
+            cocktailImageView.kf.setImage(with: imageURL)
+        } else {
+            //일단 네트워크에 저장한 이미지가없으면 보여줄 이미지를 임시로 하트로... 그럴일은 없겠지만 혹시라도 없어지면 보여야하니까
+            cocktailImageView.image = UIImage(systemName: "heart")
+        }
+        
         var justRecipe = data
         justRecipe.wishList = true
         

--- a/Cocktail/Cocktail/ViewControllers/HomeBar/AddMyOwnCocktailRecipeViewController.swift
+++ b/Cocktail/Cocktail/ViewControllers/HomeBar/AddMyOwnCocktailRecipeViewController.swift
@@ -447,7 +447,6 @@ class AddMyOwnCocktailRecipeViewController: UIViewController {
         } else if myTipTextField.text?.isEmpty ?? true {
             presentJustAlert(title: "Hold on".localized, message: "Write tips".localized)
         } else {
-
             guard let convertedImage = image.pngData(),
                 let uid = Auth.auth().currentUser?.uid else { return }
             let storageRef = Storage.storage().reference().child("CustomCocktails").child(uid).child("Recipes").child(nameTextField.text ?? "NoName"  + ".png")

--- a/Cocktail/Cocktail/ViewControllers/HomeBar/MyOwnCocktailRecipeViewController.swift
+++ b/Cocktail/Cocktail/ViewControllers/HomeBar/MyOwnCocktailRecipeViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 import SnapKit
-import SwiftUI
+import FirebaseStorage
+import FirebaseAuth
+import FirebaseDatabase
 
 class MyOwnCocktailRecipeViewController: UIViewController {
     
@@ -79,6 +81,7 @@ extension MyOwnCocktailRecipeViewController: UITableViewDelegate, UITableViewDat
         if editingStyle == .delete {
             guard let number = FirebaseRecipe.shared.myRecipe.firstIndex(of: myOwnRecipe[indexPath.row]) else { return }
             
+            //내가 가진 레시피가 wishlist에도 추가되어있다면 myrecipe를 삭제할때도 wishlist에서도 동시에 삭제되도록 해주는코드
             var recipeData = myOwnRecipe[indexPath.row]
             recipeData.wishList = true
             if FirebaseRecipe.shared.wishList.contains(recipeData) {
@@ -86,7 +89,18 @@ extension MyOwnCocktailRecipeViewController: UITableViewDelegate, UITableViewDat
                 FirebaseRecipe.shared.wishList.remove(at: wishNumber)
                 FirebaseRecipe.shared.uploadWishList()
             }
+
+            //나의 레시피가 가진 주소값을 이용하여 Storage 의 데이터를 삭제하는 코드
+            let storage = Storage.storage()
+            guard let url = myOwnRecipe[indexPath.row].imageURL else { return }
+            let storageRef = storage.reference(forURL: url)
             
+            storageRef.delete { error in
+                if let error = error{
+                    print(error)
+                }
+            }
+
             FirebaseRecipe.shared.myRecipe.remove(at: number)
             DispatchQueue.main.async {
                 FirebaseRecipe.shared.uploadMyRecipe()

--- a/Cocktail/Cocktail/ViewControllers/SettingsViewController.swift
+++ b/Cocktail/Cocktail/ViewControllers/SettingsViewController.swift
@@ -21,6 +21,7 @@ class SettingsViewController: UIViewController {
     
     func attribute() {
         logOutButton.backgroundColor = .blue
+        logOutButton.setTitle("애플 로그아웃 버튼", for: .normal)
         logOutButton.addAction(UIAction(handler: {[weak self]_ in
             let firebaseAuth = Auth.auth()
             do {


### PR DESCRIPTION
킹피셔를 사용하여 칵테일의 상세 정보탭에 들어갈떄 storage 에 있는 이미지를 불러오도록 함.
 나의 칵테일 레시피를 보여주는 창에서 나의 칵테일 레시피를 삭제하면 storage 에있는 이미지 파일도 같이 삭제되도록 함.
매번 이미지를 새로 불러오는게 부하가 클거같아서 임시 저장캐시는 어떻게 해야하나 고민했는데 킹피셔가 자동으로 캐시 메모리 관리 해주는 매우 좋은 라이러리라는것...